### PR TITLE
Fix duplicate win condition logic

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -40,12 +40,9 @@ class Game {
         this.matchedCards += 2;
         const totalCards = document.querySelectorAll('.game-board__card').length;
         if (this.matchedCards === totalCards) {
-            updateStatusMessage('You won! 🎉');
-        }
-        if (this.matchedCards === totalCards) {
             clearInterval(this.timer); // Stop the timer
             updateStatusMessage('You won! 🎉');
-        }      
+        }
     }
 
     endGame(didWin) {


### PR DESCRIPTION
## Summary
- streamline victory check logic to stop timer and show message once when all cards match

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fdf5efeac83278b33694525900bd5