### PR TITLE
Improve mobile responsiveness, header spacing, tap ergonomics, and start timer on first tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ To run the game locally, follow these steps:
 
 ---
 
+## Manual Test Checklist (Mobile)
+
+- Load the page on a ~375px-wide viewport and confirm the full grid is visible without horizontal scrolling.
+- Tap the first card and confirm the timer starts only after the first flip.
+- Flip and match a pair, then restart the game and verify the timer resets and stays idle until the next flip.
+- Tap cards quickly to ensure no text selection or double-tap zoom occurs.
+
+---
+
 ## Code Highlights
 
 Here’s an example of the code that shuffles the card symbols:

--- a/js/board.js
+++ b/js/board.js
@@ -22,7 +22,7 @@ export function createBoard(pairCount = trees.length) {
 
 function setGridColumns(board, totalCards) {
     const columns = Math.ceil(Math.sqrt(totalCards));
-    board.style.gridTemplateColumns = `repeat(${columns}, minmax(${CONFIG.CARD_SIZE}px, 1fr))`;
+    board.style.gridTemplateColumns = `repeat(${columns}, minmax(0, 1fr))`;
     board.style.maxWidth = `${CONFIG.GRID_MAX_WIDTH}px`;
 }
 
@@ -34,7 +34,10 @@ function updateCSSVariables() {
 export function initializeBoard() {
     updateCSSVariables();
     const board = document.getElementById('game-board');
-    board.addEventListener('click', (event) => {
+    board.addEventListener('pointerup', (event) => {
+        if (event.pointerType === 'mouse' && event.button !== 0) {
+            return;
+        }
         const card = event.target.closest('.game-board__card');
         if (card) flipCard(card);
     });

--- a/js/cards.js
+++ b/js/cards.js
@@ -14,6 +14,7 @@ export function flipCard(card) {
         return;
     }
 
+    game.startTimerOnce();
     card.classList.add('game-board__card--flipped');
     card.textContent = card.dataset.symbol;
     flippedCards.push(card);

--- a/js/game.js
+++ b/js/game.js
@@ -7,18 +7,20 @@ class Game {
         this.difficulty = 'medium';
         this.moves = 0;
         this.matchedCards = 0;
-        this.timer = null; // Timer interval ID
+        this.timerId = null; // Timer interval ID
         this.timeLeft = DIFFICULTIES[this.difficulty].time; // Time left in seconds
     }
 
-    startTimer() {
-        this.timeLeft = DIFFICULTIES[this.difficulty].time; // Reset the timer
-        document.getElementById('timer').textContent = this.timeLeft;
-        this.timer = setInterval(() => {
+    startTimerOnce() {
+        if (this.timerId) {
+            return;
+        }
+        this.timerId = setInterval(() => {
             this.timeLeft--;
             document.getElementById('timer').textContent = this.timeLeft;
             if (this.timeLeft <= 0) {
-                clearInterval(this.timer);
+                clearInterval(this.timerId);
+                this.timerId = null;
                 this.endGame(false); // End game if timer runs out
             }
         }, 1000);
@@ -46,13 +48,15 @@ class Game {
         this.matchedCards += 2;
         const totalCards = document.querySelectorAll('.game-board__card').length;
         if (this.matchedCards === totalCards) {
-            clearInterval(this.timer); // Stop the timer
+            clearInterval(this.timerId); // Stop the timer
+            this.timerId = null;
             updateStatusMessage('You won! 🎉');
         }
     }
 
     endGame(didWin) {
-        clearInterval(this.timer); // Stop the timer
+        clearInterval(this.timerId); // Stop the timer
+        this.timerId = null;
         const message = didWin ? 'You won! 🎉' : 'Time’s up! Try again!';
         updateStatusMessage(message);
         // Disable all cards to prevent further interaction
@@ -61,13 +65,15 @@ class Game {
     }
     
     resetGame() {
-        clearInterval(this.timer); // Stop any running timer
+        clearInterval(this.timerId); // Stop any running timer
+        this.timerId = null;
         this.moves = 0;
         this.matchedCards = 0;
         setMoveCounter(this.moves);
         updateStatusMessage('');
         createBoard(DIFFICULTIES[this.difficulty].pairs);
-        this.startTimer(); // Start a new timer
+        this.timeLeft = DIFFICULTIES[this.difficulty].time;
+        document.getElementById('timer').textContent = this.timeLeft;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,9 @@
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
 :root {
     /* Colors */
     --color-background: #e9f5e1;
@@ -30,6 +36,7 @@ body {
     text-align: center;
     background-color: var(--color-background);
     color: var(--color-text);
+    overflow-x: hidden;
 }
 
 .header {
@@ -40,10 +47,12 @@ body {
 
 .header__title {
     margin: 0;
+    font-size: clamp(1.6rem, 2.8vw + 1rem, 2.6rem);
 }
 
 .header__description {
     margin: 10px 0 0;
+    font-size: clamp(0.95rem, 1.2vw + 0.75rem, 1.2rem);
 }
 
 .main {
@@ -59,11 +68,12 @@ body {
     max-width: var(--grid-max-width);
     margin: 20px auto;
     grid-template-columns: repeat(auto-fit, minmax(var(--card-size), 1fr));
+    width: min(92vw, var(--grid-max-width));
 }
 
 .game-board__card {
-    width: var(--card-size);
-    height: var(--card-size);
+    width: 100%;
+    aspect-ratio: 1 / 1;
     background-color: var(--color-card-bg);
     border: 2px solid var(--color-card-border);
     border-radius: 8px;
@@ -73,6 +83,10 @@ body {
     align-items: center;
     font-size: 0;
     transition: transform var(--animation-speed) ease, background-color var(--animation-speed);
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
 }
 
 .game-board__card--flipped,
@@ -98,11 +112,13 @@ body {
 }
 
 .scoreboard__difficulty select {
-    padding: 5px;
+    padding: 8px 12px;
+    min-height: 44px;
 }
 
 .scoreboard__reset-button {
     padding: 10px 20px;
+    min-height: 44px;
     background-color: var(--color-button-bg);
     color: var(--color-button-text);
     border: none;
@@ -110,6 +126,7 @@ body {
     cursor: pointer;
     font-size: var(--font-size-base);
     transition: background-color var(--animation-speed);
+    touch-action: manipulation;
 }
 
 .scoreboard__reset-button:hover {
@@ -120,4 +137,27 @@ body {
     margin: 10px 0;
     font-size: var(--font-size-base);
     font-weight: bold;
+}
+
+@media (max-width: 480px) {
+    .header {
+        padding: 12px 16px;
+    }
+
+    .header__description {
+        margin-top: 6px;
+    }
+
+    .main {
+        padding: 12px;
+    }
+
+    .game-board {
+        margin: 12px auto;
+        gap: 8px;
+    }
+
+    .scoreboard {
+        margin-top: 16px;
+    }
 }


### PR DESCRIPTION
### Motivation

- Prevent the game board from overflowing on narrow viewports and make cards scale with the grid so no column is clipped on mobile. 
- Reduce the vertical footprint of the header on small screens so the board and controls are more visible above the fold. 
- Ensure the countdown timer starts only when the player makes the first meaningful action (first card flip) rather than on page load. 
- Improve tap ergonomics to avoid text selection, tap highlights, and double-tap zoom on touch devices.

### Description

- Made the layout and card sizing responsive by adding global `box-sizing`, setting `.game-board` width to `min(92vw, var(--grid-max-width))`, changing cards to `width: 100%` with `aspect-ratio: 1 / 1`, and switching grid columns to `repeat(${columns}, minmax(0, 1fr))` in `js/board.js` to allow the container to shrink.
- Reduced header sizing and vertical spacing on small screens by adding `clamp()` typography for `.header__title` and `.header__description` and a `@media (max-width: 480px)` rule to trim padding in `styles.css`.
- Changed input handling to `pointerup` with a mouse-button guard in `js/board.js` and improved tap ergonomics in `styles.css` by adding `user-select: none`, `touch-action: manipulation`, and `-webkit-tap-highlight-color: transparent` on cards and touch-action hints on controls.
- Implemented timer start-on-first-interaction by introducing `startTimerOnce()` and `timerId` guards in `js/game.js`, calling `game.startTimerOnce()` from `js/cards.js` on the first successful `flipCard`, and ensuring the timer is reset/cleared on restart and on game end; updated `README.md` with a simple mobile manual test checklist.

Files changed: `styles.css`, `js/board.js`, `js/game.js`, `js/cards.js`, and `README.md`.

### Testing

- Started a local static server with `python -m http.server` and navigated to the page using an automated Playwright script configured to a mobile viewport (375×812), and captured a full-page screenshot, which completed successfully. 
- The Playwright navigation and screenshot run served as a smoke test that the responsive grid renders at mobile width and the page loads without blocking errors during load. 
- Manual mobile checklist was added to `README.md` for follow-up hands-on validation across iOS Safari and Chrome Android. 
- No automated unit tests exist in the repo, so no other test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6955ae02032c8321a6064dda77459cfc)