### PR TITLE
Add scoring, streaks, match/mismatch feedback, audio, and end-of-game summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@
 ## Features
 
 - **Interactive Gameplay**: Match pairs of cards to win.
-- **Dynamic Scoring**: Track your moves as you play.
+- **Dynamic Scoring**: Score points for matches with streak multipliers.
 - **Four Difficulty Levels**: Choose from Easy, Medium, Hard, or Expert.
 - **Responsive Design**: Looks great on any screen size.
 - **Tree Theme**: Cards feature delightful tree symbols like 🌲 and 🌳.
+- **Best Results Tracking**: Best score, time, moves, and streak persist per difficulty.
+- **End-of-Game Summary**: Result screen with accuracy, streaks, and badges.
+- **Optional Audio**: Lightweight match/mismatch/win tones with a mute-by-default toggle.
 
 ---
 
@@ -22,6 +25,42 @@
 3. Click on another card to find its match.
 4. Match all pairs to complete the game.
 5. Restart at any time with the "Restart Game" button.
+
+---
+
+## Scoring & Streak Rules
+
+- **Match points**: +100 points per match.
+- **Streak multipliers**: consecutive matches boost points.
+  - Streak 1: x1
+  - Streak 2: x1.2
+  - Streak 3: x1.4
+  - Streak 4+: x1.6 (capped at x2)
+- **Mismatch penalty**: -20 points (score never goes below 0).
+
+Moves count each pair attempt (every two flips).
+
+---
+
+## Persistence
+
+Best results are saved per difficulty in `localStorage`, under keys like:
+`treeMemory.best.easy`. Stored metrics include best score, fastest win time,
+fewest moves, best streak, and total games played.
+
+Audio preference is stored at `treeMemory.audio.enabled` and is muted by default.
+
+---
+
+## Tuning Gameplay & Rewards
+
+Scoring, streak multipliers, and par targets live in `js/config.js`:
+
+- `CONFIG.SCORE_MATCH`, `CONFIG.SCORE_MISMATCH_PENALTY`
+- `CONFIG.STREAK_MULTIPLIERS`
+- `DIFFICULTY.*.parTimeSec`, `DIFFICULTY.*.parMoves`, `DIFFICULTY.*.streakBadge`
+
+Adjust these values to tune difficulty and badge thresholds.
 
 ---
 
@@ -63,22 +102,29 @@ To run the game locally, follow these steps:
 ## QA Checklist
 
 ### Gameplay
+- Score increases on match and applies streak multipliers.
+- Mismatch resets streak and applies penalty.
 - Each difficulty produces the correct number of cards and pairs.
 - Preview works (cards flip up then down) and blocks input.
 - Timer starts after preview ends (or on first flip for Expert).
 - Restart clears timers and timeouts; no stacked intervals.
 - Win condition works for all difficulties.
 - Loss condition works for timed difficulties.
+- End-of-game summary appears on win/loss.
+- Best results persist per difficulty across refreshes.
 
 ### UI
 - Board displays correctly for each difficulty.
 - No horizontal overflow on mobile.
 - No console errors.
+- Animations play on match/mismatch and respect reduced motion.
+- Summary modal is responsive and legible on mobile.
 
 ### Edge Cases
 - Restart during preview.
 - Change difficulty during preview.
 - Rapid tapping during mismatch delay.
+- Restart or change difficulty from the summary modal.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,14 @@
         <p class="hud__hint" id="difficulty-detail"></p>
       </div>
       <div class="hud__item">
+        <span class="hud__label">Score</span>
+        <span class="hud__value" id="score-counter">0</span>
+      </div>
+      <div class="hud__item">
+        <span class="hud__label">Streak</span>
+        <span class="hud__value" id="streak-counter">0</span>
+      </div>
+      <div class="hud__item">
         <span class="hud__label">Moves</span>
         <span class="hud__value" id="move-counter">0</span>
       </div>
@@ -40,9 +48,60 @@
     </section>
     <section class="controls">
       <p class="status-message" id="status-message"></p>
+      <label class="audio-toggle" for="audio-toggle">
+        <input type="checkbox" id="audio-toggle" />
+        <span>Sound</span>
+      </label>
       <button class="controls__reset-button" id="reset-button">Restart Game</button>
     </section>
   </main>
+  <div class="modal modal--hidden" id="summary-modal" aria-hidden="true">
+    <div class="modal__backdrop" data-modal-close></div>
+    <div class="modal__content" role="dialog" aria-modal="true" aria-labelledby="summary-title">
+      <h2 class="modal__title" id="summary-title">Game Over</h2>
+      <p class="modal__result" id="summary-result"></p>
+      <div class="modal__grid">
+        <div>
+          <p class="modal__label">Difficulty</p>
+          <p class="modal__value" id="summary-difficulty"></p>
+        </div>
+        <div>
+          <p class="modal__label">Final Score</p>
+          <p class="modal__value" id="summary-score"></p>
+        </div>
+        <div>
+          <p class="modal__label" id="summary-time-label">Time</p>
+          <p class="modal__value" id="summary-time"></p>
+        </div>
+        <div>
+          <p class="modal__label">Moves</p>
+          <p class="modal__value" id="summary-moves"></p>
+        </div>
+        <div>
+          <p class="modal__label">Accuracy</p>
+          <p class="modal__value" id="summary-accuracy"></p>
+        </div>
+        <div>
+          <p class="modal__label">Max Streak</p>
+          <p class="modal__value" id="summary-max-streak"></p>
+        </div>
+      </div>
+      <div class="badges" id="summary-badges"></div>
+      <div class="modal__best">
+        <h3 class="modal__subtitle">Best on this difficulty</h3>
+        <ul class="modal__list">
+          <li><span>Best Score</span><strong id="best-score">0</strong></li>
+          <li><span>Best Time</span><strong id="best-time">--</strong></li>
+          <li><span>Best Moves</span><strong id="best-moves">--</strong></li>
+          <li><span>Best Streak</span><strong id="best-streak">0</strong></li>
+        </ul>
+      </div>
+      <div class="modal__actions">
+        <button class="controls__reset-button" id="summary-restart">Play Again</button>
+        <button class="modal__link" id="summary-difficulty-link" type="button">Change Difficulty</button>
+      </div>
+    </div>
+  </div>
   <footer class="footer">
     <p class="footer__credits">Created by Jack River</p>
   </footer>

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,0 +1,84 @@
+const STORAGE_KEY = 'treeMemory.audio.enabled';
+
+class AudioManager {
+    constructor() {
+        this.enabled = false;
+        this.context = null;
+        this.masterGain = null;
+    }
+
+    loadPreference() {
+        this.enabled = localStorage.getItem(STORAGE_KEY) === 'true';
+        return this.enabled;
+    }
+
+    setEnabled(enabled) {
+        this.enabled = enabled;
+        localStorage.setItem(STORAGE_KEY, String(enabled));
+        if (enabled) {
+            this.ensureContext();
+        }
+    }
+
+    ensureContext() {
+        if (!this.context) {
+            const AudioContext = window.AudioContext || window.webkitAudioContext;
+            if (!AudioContext) return;
+            this.context = new AudioContext();
+            this.masterGain = this.context.createGain();
+            this.masterGain.gain.value = 0.12;
+            this.masterGain.connect(this.context.destination);
+        }
+        if (this.context.state === 'suspended') {
+            this.context.resume();
+        }
+    }
+
+    playTone({ frequency, duration = 0.18, type = 'sine' }) {
+        if (!this.enabled) return;
+        this.ensureContext();
+        if (!this.context || !this.masterGain) return;
+        const oscillator = this.context.createOscillator();
+        const gain = this.context.createGain();
+        oscillator.type = type;
+        oscillator.frequency.value = frequency;
+        gain.gain.setValueAtTime(0, this.context.currentTime);
+        gain.gain.linearRampToValueAtTime(0.8, this.context.currentTime + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.001, this.context.currentTime + duration);
+        oscillator.connect(gain);
+        gain.connect(this.masterGain);
+        oscillator.start();
+        oscillator.stop(this.context.currentTime + duration);
+    }
+
+    playMatch() {
+        this.playTone({ frequency: 620, duration: 0.2, type: 'triangle' });
+    }
+
+    playMismatch() {
+        this.playTone({ frequency: 220, duration: 0.22, type: 'square' });
+    }
+
+    playWin() {
+        if (!this.enabled) return;
+        this.ensureContext();
+        if (!this.context || !this.masterGain) return;
+        const now = this.context.currentTime;
+        const notes = [440, 554, 659];
+        notes.forEach((frequency, index) => {
+            const oscillator = this.context.createOscillator();
+            const gain = this.context.createGain();
+            oscillator.type = 'triangle';
+            oscillator.frequency.value = frequency;
+            gain.gain.setValueAtTime(0.001, now + index * 0.08);
+            gain.gain.linearRampToValueAtTime(0.7, now + index * 0.08 + 0.03);
+            gain.gain.exponentialRampToValueAtTime(0.001, now + index * 0.08 + 0.3);
+            oscillator.connect(gain);
+            gain.connect(this.masterGain);
+            oscillator.start(now + index * 0.08);
+            oscillator.stop(now + index * 0.08 + 0.3);
+        });
+    }
+}
+
+export const audioManager = new AudioManager();

--- a/js/cards.js
+++ b/js/cards.js
@@ -40,11 +40,16 @@ function checkForMatch() {
 function markAsMatched(card1, card2) {
     card1.classList.add('game-board__card--matched', 'game-board__card--disabled');
     card2.classList.add('game-board__card--matched', 'game-board__card--disabled');
+    animateCard(card1, 'matched-animate');
+    animateCard(card2, 'matched-animate');
     flippedCards = [];
     game.handleMatch();
 }
 
 function unflipCards(card1, card2) {
+    animateCard(card1, 'mismatch-animate');
+    animateCard(card2, 'mismatch-animate');
+    game.handleMismatch();
     const delay = game.getMismatchDelayMs();
     mismatchTimeoutId = setTimeout(() => {
         card1.classList.remove('game-board__card--flipped');
@@ -55,6 +60,15 @@ function unflipCards(card1, card2) {
         isClickLocked = false;
         mismatchTimeoutId = null;
     }, delay);
+}
+
+function animateCard(card, className) {
+    card.classList.remove(className);
+    void card.offsetWidth;
+    card.classList.add(className);
+    const removeAnimation = () => card.classList.remove(className);
+    card.addEventListener('animationend', removeAnimation, { once: true });
+    setTimeout(removeAnimation, 300);
 }
 
 export function resetFlippedCards() {

--- a/js/config.js
+++ b/js/config.js
@@ -2,6 +2,9 @@ export const CONFIG = {
     CARD_FLIP_DELAY: 1000,
     CARD_SIZE: 100,
     GRID_MAX_WIDTH: 600,
+    SCORE_MATCH: 100,
+    SCORE_MISMATCH_PENALTY: 20,
+    STREAK_MULTIPLIERS: [1, 1.2, 1.4, 1.6, 1.8, 2],
 };
 
 export const DIFFICULTY = {
@@ -13,6 +16,9 @@ export const DIFFICULTY = {
         mismatchDelayMs: 1100,
         timerStart: 'afterPreview',
         label: 'Easy: 12 cards, long preview, no time limit.',
+        parTimeSec: 60,
+        parMoves: 10,
+        streakBadge: 4,
     },
     medium: {
         rows: 4,
@@ -22,6 +28,9 @@ export const DIFFICULTY = {
         mismatchDelayMs: 900,
         timerStart: 'afterPreview',
         label: 'Medium: 16 cards, moderate preview, 90s limit.',
+        parTimeSec: 55,
+        parMoves: 14,
+        streakBadge: 5,
     },
     hard: {
         rows: 4,
@@ -31,6 +40,9 @@ export const DIFFICULTY = {
         mismatchDelayMs: 800,
         timerStart: 'afterPreview',
         label: 'Hard: 20 cards, short preview, 75s limit.',
+        parTimeSec: 65,
+        parMoves: 18,
+        streakBadge: 6,
     },
     expert: {
         rows: 6,
@@ -40,5 +52,8 @@ export const DIFFICULTY = {
         mismatchDelayMs: 650,
         timerStart: 'onFirstFlip',
         label: 'Expert: 36 cards, lightning preview, 120s limit.',
+        parTimeSec: 110,
+        parMoves: 30,
+        streakBadge: 8,
     },
 };

--- a/js/game.js
+++ b/js/game.js
@@ -1,13 +1,25 @@
 import { createBoard, initializeBoard } from './board.js';
-import { setMoveCounter, updateDifficultyLabel, updateStatusMessage, updateTimerLabel, updateTimerValue } from './ui.js';
-import { DIFFICULTY } from './config.js';
+import {
+    setMoveCounter,
+    updateDifficultyLabel,
+    updateScore,
+    updateStatusMessage,
+    updateStreak,
+    updateTimerLabel,
+    updateTimerValue,
+    setAudioToggle,
+} from './ui.js';
+import { CONFIG, DIFFICULTY } from './config.js';
 import { resetFlippedCards } from './cards.js';
+import { audioManager } from './audio.js';
 
 class Game {
     constructor() {
         this.difficulty = 'medium';
         this.moves = 0;
         this.matchedCards = 0;
+        this.matches = 0;
+        this.mismatches = 0;
         this.timerId = null;
         this.previewTimeoutId = null;
         this.isLocked = false;
@@ -15,6 +27,14 @@ class Game {
         this.timerStarted = false;
         this.timeLeft = 0;
         this.timeElapsed = 0;
+        this.score = 0;
+        this.streak = 0;
+        this.maxStreak = 0;
+        this.summaryModal = document.getElementById('summary-modal');
+        this.summaryRestartButton = document.getElementById('summary-restart');
+        this.summaryDifficultyLink = document.getElementById('summary-difficulty-link');
+        this.audioToggle = document.getElementById('audio-toggle');
+        this.lastFocusedElement = null;
     }
 
     startTimerOnce() {
@@ -50,6 +70,25 @@ class Game {
             this.difficulty = e.target.value;
             this.resetGame();
         });
+        this.summaryRestartButton.addEventListener('click', () => {
+            this.closeSummary();
+            this.resetGame();
+        });
+        this.summaryDifficultyLink.addEventListener('click', () => {
+            this.closeSummary();
+            difficultySelect.focus();
+        });
+        this.summaryModal.addEventListener('click', (event) => {
+            if (event.target.matches('[data-modal-close]')) {
+                this.closeSummary();
+            }
+        });
+        this.summaryModal.addEventListener('keydown', (event) => this.handleModalKeydown(event));
+        const audioEnabled = audioManager.loadPreference();
+        setAudioToggle(audioEnabled);
+        this.audioToggle.addEventListener('change', (event) => {
+            audioManager.setEnabled(event.target.checked);
+        });
         initializeBoard();
         this.resetGame();
     }
@@ -84,10 +123,35 @@ class Game {
 
     handleMatch() {
         this.matchedCards += 2;
+        this.matches += 1;
+        this.streak += 1;
+        this.maxStreak = Math.max(this.maxStreak, this.streak);
+        const multiplier = this.getStreakMultiplier();
+        this.addScore(CONFIG.SCORE_MATCH * multiplier);
+        updateStreak(this.streak);
+        audioManager.playMatch();
         const totalCards = document.querySelectorAll('.game-board__card').length;
         if (this.matchedCards === totalCards) {
             this.endGame(true);
         }
+    }
+
+    handleMismatch() {
+        this.mismatches += 1;
+        this.streak = 0;
+        updateStreak(this.streak);
+        this.addScore(-CONFIG.SCORE_MISMATCH_PENALTY);
+        audioManager.playMismatch();
+    }
+
+    getStreakMultiplier() {
+        const index = Math.min(this.streak - 1, CONFIG.STREAK_MULTIPLIERS.length - 1);
+        return CONFIG.STREAK_MULTIPLIERS[index] ?? 1;
+    }
+
+    addScore(value) {
+        this.score = Math.max(0, Math.round(this.score + value));
+        updateScore(this.score);
     }
 
     endGame(didWin) {
@@ -98,14 +162,26 @@ class Game {
         // Disable all cards to prevent further interaction
         const cards = document.querySelectorAll('.game-board__card');
         cards.forEach(card => card.classList.add('game-board__card--disabled'));
+        if (didWin) {
+            audioManager.playWin();
+        }
+        this.openSummary(didWin);
     }
     
     resetGame() {
         this.stopTimer();
         this.clearPreviewTimeout();
+        this.closeSummary();
         this.moves = 0;
         this.matchedCards = 0;
+        this.matches = 0;
+        this.mismatches = 0;
+        this.score = 0;
+        this.streak = 0;
+        this.maxStreak = 0;
         setMoveCounter(this.moves);
+        updateScore(this.score);
+        updateStreak(this.streak);
         updateStatusMessage('');
         resetFlippedCards();
         const config = this.getDifficultyConfig();
@@ -113,6 +189,7 @@ class Game {
         updateDifficultyLabel(config.label);
         this.setupTimer(config);
         this.startPreview(config);
+        this.lockInteractions(false);
     }
 
     setupTimer(config) {
@@ -165,6 +242,154 @@ class Game {
             this.timerId = null;
         }
         this.timerStarted = false;
+    }
+
+    getElapsedTime(config) {
+        if (config.timeLimitSec === null) {
+            return this.timeElapsed;
+        }
+        return Math.max(config.timeLimitSec - this.timeLeft, 0);
+    }
+
+    formatTime(seconds) {
+        const mins = Math.floor(seconds / 60);
+        const secs = seconds % 60;
+        if (mins === 0) {
+            return `${secs}s`;
+        }
+        return `${mins}m ${secs}s`;
+    }
+
+    getBestKey() {
+        return `treeMemory.best.${this.difficulty}`;
+    }
+
+    loadBestStats() {
+        const saved = localStorage.getItem(this.getBestKey());
+        if (!saved) {
+            return {
+                bestScore: 0,
+                bestTime: null,
+                bestMoves: null,
+                bestStreak: 0,
+                gamesPlayed: 0,
+            };
+        }
+        try {
+            return JSON.parse(saved);
+        } catch (error) {
+            return {
+                bestScore: 0,
+                bestTime: null,
+                bestMoves: null,
+                bestStreak: 0,
+                gamesPlayed: 0,
+            };
+        }
+    }
+
+    saveBestStats(stats) {
+        localStorage.setItem(this.getBestKey(), JSON.stringify(stats));
+    }
+
+    updateBestStats({ didWin, elapsedTime }) {
+        const stats = this.loadBestStats();
+        stats.gamesPlayed += 1;
+        if (this.score > stats.bestScore) {
+            stats.bestScore = this.score;
+        }
+        if (this.maxStreak > stats.bestStreak) {
+            stats.bestStreak = this.maxStreak;
+        }
+        if (didWin) {
+            if (stats.bestMoves === null || this.moves < stats.bestMoves) {
+                stats.bestMoves = this.moves;
+            }
+            if (stats.bestTime === null || elapsedTime < stats.bestTime) {
+                stats.bestTime = elapsedTime;
+            }
+        }
+        this.saveBestStats(stats);
+        return stats;
+    }
+
+    openSummary(didWin) {
+        const config = this.getDifficultyConfig();
+        const elapsedTime = this.getElapsedTime(config);
+        const timeLabel = config.timeLimitSec === null ? 'Time Elapsed' : 'Time Left';
+        const timeValue = config.timeLimitSec === null
+            ? elapsedTime
+            : Math.max(this.timeLeft, 0);
+        const accuracy = this.moves === 0 ? 0 : Math.round((this.matches / this.moves) * 100);
+        const stats = this.updateBestStats({ didWin, elapsedTime });
+        document.getElementById('summary-result').textContent = didWin ? 'You Win! 🌟' : 'Time’s Up!';
+        document.getElementById('summary-difficulty').textContent = config.label.split(':')[0];
+        document.getElementById('summary-score').textContent = this.score;
+        document.getElementById('summary-time-label').textContent = timeLabel;
+        document.getElementById('summary-time').textContent = this.formatTime(timeValue);
+        document.getElementById('summary-moves').textContent = this.moves;
+        document.getElementById('summary-accuracy').textContent = `${accuracy}%`;
+        document.getElementById('summary-max-streak').textContent = this.maxStreak;
+        document.getElementById('best-score').textContent = stats.bestScore;
+        document.getElementById('best-time').textContent = stats.bestTime === null ? '--' : this.formatTime(stats.bestTime);
+        document.getElementById('best-moves').textContent = stats.bestMoves === null ? '--' : stats.bestMoves;
+        document.getElementById('best-streak').textContent = stats.bestStreak;
+        this.renderBadges({ didWin, elapsedTime, config });
+        this.lastFocusedElement = document.activeElement;
+        this.summaryModal.classList.remove('modal--hidden');
+        this.summaryModal.setAttribute('aria-hidden', 'false');
+        this.summaryRestartButton.focus();
+    }
+
+    closeSummary() {
+        this.summaryModal.classList.add('modal--hidden');
+        this.summaryModal.setAttribute('aria-hidden', 'true');
+        if (this.lastFocusedElement && this.lastFocusedElement.focus) {
+            this.lastFocusedElement.focus();
+        }
+    }
+
+    renderBadges({ didWin, elapsedTime, config }) {
+        const badges = [];
+        if (didWin && elapsedTime <= config.parTimeSec) {
+            badges.push({ label: 'Beat par time', className: 'badge badge--par' });
+        }
+        if (didWin && this.mismatches === 0) {
+            badges.push({ label: 'Perfect (0 mismatches)', className: 'badge badge--perfect' });
+        }
+        if (this.maxStreak >= config.streakBadge) {
+            badges.push({ label: 'Streak Master', className: 'badge badge--streak' });
+        }
+        const container = document.getElementById('summary-badges');
+        container.innerHTML = '';
+        badges.forEach((badge) => {
+            const span = document.createElement('span');
+            span.className = badge.className;
+            span.textContent = badge.label;
+            container.appendChild(span);
+        });
+    }
+
+    handleModalKeydown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.closeSummary();
+            return;
+        }
+        if (event.key !== 'Tab') return;
+        const focusable = this.summaryModal.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
     }
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -17,3 +17,15 @@ export function updateDifficultyLabel(text) {
 export function updateStatusMessage(message) {
     document.getElementById('status-message').textContent = message;
 }
+
+export function updateScore(value) {
+    document.getElementById('score-counter').textContent = value;
+}
+
+export function updateStreak(value) {
+    document.getElementById('streak-counter').textContent = value;
+}
+
+export function setAudioToggle(checked) {
+    document.getElementById('audio-toggle').checked = checked;
+}

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,14 @@ body {
     box-shadow: 0 0 0 2px rgba(74, 167, 101, 0.5), 0 10px 18px rgba(74, 167, 101, 0.25);
 }
 
+.game-board__card.matched-animate {
+    animation: match-pop 0.22s ease-out;
+}
+
+.game-board__card.mismatch-animate {
+    animation: mismatch-shake 0.24s ease-in-out;
+}
+
 .controls {
     display: flex;
     flex-direction: column;
@@ -240,10 +248,207 @@ body {
     outline-offset: 3px;
 }
 
+.audio-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.audio-toggle input {
+    width: 18px;
+    height: 18px;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    z-index: 10;
+}
+
+.modal--hidden {
+    display: none;
+}
+
+.modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(12, 24, 18, 0.5);
+}
+
+.modal__content {
+    position: relative;
+    width: min(92vw, 640px);
+    background: var(--surface-elevated);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    padding: 24px;
+    box-shadow: var(--shadow);
+    text-align: left;
+}
+
+.modal__title {
+    margin: 0 0 6px;
+    font-size: clamp(1.6rem, 2.2vw + 1rem, 2.2rem);
+}
+
+.modal__result {
+    margin: 0 0 18px;
+    font-weight: 600;
+    color: var(--accent-2);
+}
+
+.modal__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 14px;
+    margin-bottom: 16px;
+}
+
+.modal__label {
+    margin: 0 0 4px;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 600;
+}
+
+.modal__value {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.modal__best {
+    background: var(--surface);
+    border-radius: var(--radius);
+    padding: 14px;
+    border: 1px solid var(--border);
+    margin-bottom: 16px;
+}
+
+.modal__subtitle {
+    margin: 0 0 10px;
+    font-size: 0.95rem;
+}
+
+.modal__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.modal__list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.95rem;
+}
+
+.modal__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.modal__link {
+    background: none;
+    border: none;
+    color: var(--accent-2);
+    font-weight: 600;
+    cursor: pointer;
+    padding: 10px 12px;
+    min-height: 44px;
+}
+
+.modal__link:focus-visible {
+    outline: 3px solid rgba(74, 167, 101, 0.45);
+    outline-offset: 3px;
+    border-radius: 999px;
+}
+
+.badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.badge {
+    background: rgba(74, 167, 101, 0.12);
+    color: var(--accent-2);
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.badge--perfect {
+    background: rgba(74, 122, 167, 0.12);
+    color: #2a5f87;
+}
+
+.badge--streak {
+    background: rgba(167, 74, 128, 0.12);
+    color: #7a2f5d;
+}
+
+.badge--par {
+    background: rgba(74, 167, 101, 0.18);
+}
+
+.hud__item--wide {
+    grid-column: span 2;
+}
+
 .footer {
     padding: 16px 12px 28px;
     color: var(--muted);
     font-size: 0.9rem;
+}
+
+@keyframes match-pop {
+    0% {
+        transform: scale(1);
+        box-shadow: 0 0 0 rgba(74, 167, 101, 0);
+    }
+    50% {
+        transform: scale(1.08);
+        box-shadow: 0 0 0 6px rgba(74, 167, 101, 0.2);
+    }
+    100% {
+        transform: scale(1.02);
+        box-shadow: 0 0 0 rgba(74, 167, 101, 0);
+    }
+}
+
+@keyframes mismatch-shake {
+    0%,
+    100% {
+        transform: translateX(0);
+    }
+    25% {
+        transform: translateX(-4px);
+    }
+    50% {
+        transform: translateX(4px);
+    }
+    75% {
+        transform: translateX(-2px);
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -252,6 +457,11 @@ body {
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
         scroll-behavior: auto !important;
+    }
+
+    .game-board__card.matched-animate,
+    .game-board__card.mismatch-animate {
+        animation: none;
     }
 }
 


### PR DESCRIPTION
### Motivation

- Provide lightweight reward and replayability features: scoring, streak multipliers, and persistent best-results per difficulty.  
- Give immediate satisfying feedback for matches/mismatches with short animations and optional sound.  
- Surface final performance with an accessible end-of-game summary and small QoL HUD improvements.  
- Keep the implementation minimal, framework-free, mobile-friendly, and respectful of `prefers-reduced-motion`.

### Description

- Add scoring and tuning constants in `js/config.js` (`CONFIG.SCORE_MATCH`, `CONFIG.SCORE_MISMATCH_PENALTY`, and `CONFIG.STREAK_MULTIPLIERS`) and par/badge targets in each `DIFFICULTY` entry.  
- Implement an `AudioManager` in `js/audio.js` to optionally play lightweight tones (muted by default and persisted at `treeMemory.audio.enabled`).  
- Update HUD and UI: add `score` and `streak` counters and an audio toggle in `index.html`, plus a responsive summary modal with metrics, badges, and best-results display.  
- Wire scoring, streaks, animations, persistence and modal flow into game logic in `js/game.js` and `js/cards.js`, add CSS animations in `styles.css`, and small UI helpers in `js/ui.js`; document rules and tuning in `README.md`.

### Testing

- Ran a local static server (`python -m http.server`) and an automated Playwright smoke test to open `http://127.0.0.1:8000/` and capture a screenshot, which loaded successfully.  
- No unit tests were added; changes were validated via the smoke test and manual inspection of UI elements in the captured screenshot.  
- The patch was committed and includes the following modified/added files: `index.html`, `styles.css`, `js/game.js`, `js/cards.js`, `js/config.js`, `js/ui.js`, `js/audio.js`, and `README.md`.  
- Accessibility and motion-respect are implemented: animations are short (<=250ms) and disabled under `prefers-reduced-motion`, and the summary modal supports keyboard closing (Escape) and focus trapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6955b9129e888321bcd8f30abfb34cf7)