### PR TITLE
Fix game board overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,10 +137,9 @@ body {
 .game-board {
     display: grid;
     gap: clamp(10px, 1.6vw, 14px);
-    max-width: var(--grid-max-width);
     margin: 0 auto;
     grid-template-columns: repeat(auto-fit, minmax(var(--card-size), 1fr));
-    width: min(92vw, var(--grid-max-width));
+    width: min(100%, var(--grid-max-width));
 }
 
 .game-board__card {


### PR DESCRIPTION
### Motivation
- Prevent the game cards from spilling horizontally beyond the board container on narrow viewports.
- Ensure the layout respects the board shell's available width so the grid doesn't produce horizontal scrolling.

### Description
- Updated `.game-board` sizing to use `width: min(100%, var(--grid-max-width))` so it never exceeds its container.
- Removed the redundant `max-width: var(--grid-max-width)` to avoid conflicting constraints with the new width rule.
- Kept the responsive grid behavior via `grid-template-columns: repeat(auto-fit, minmax(var(--card-size), 1fr))`.

### Testing
- Served the site with `python -m http.server` and ran a Playwright script that opened the page and captured `artifacts/board-layout.png` successfully.
- Verified the CSS change visually via the captured screenshot and observed no horizontal overflow.
- No automated unit tests were added or run for this styling-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6955bc62a70c83218f3d2b63208551a8)